### PR TITLE
Add TLS support with optional host/cert verification

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -6,11 +6,11 @@ try: input = raw_input
 except NameError: pass
 
 
-def main(host, port, password):
+def main(host, port, password, tlsmode):
     rcon = mcrcon.MCRcon()
 
     print("# connecting to %s:%i..." % (host, port))
-    rcon.connect(host, port, password)
+    rcon.connect(host, port, password, tlsmode)
 
     print("# ready")
 
@@ -28,9 +28,10 @@ def main(host, port, password):
 if __name__ == '__main__':
     import sys
     args = sys.argv[1:]
-    if len(args) != 3:
-        print("usage: python demo.py <host> <port> <password>")
+    if len(args) != 4:
+        print("usage: python demo.py <host> <port> <password> <tlsmode>")
         sys.exit(1)
-    host, port, password = args
+    host, port, password, tlsmode = args
     port = int(port)
-    main(host, port, password)
+    tlsmode = int(tlsmode)
+    main(host, port, password, tlsmode)

--- a/mcrcon.py
+++ b/mcrcon.py
@@ -1,4 +1,5 @@
 import socket
+import ssl
 import select
 import struct
 import time
@@ -11,10 +12,22 @@ class MCRconException(Exception):
 class MCRcon(object):
     socket = None
 
-    def connect(self, host, port, password):
+    def connect(self, host, port, password, tlsmode):
         if self.socket is not None:
             raise MCRconException("Already connected")
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        # Enable TLS
+        if tlsmode > 0:
+            ctx = ssl.create_default_context()
+
+            # Disable hostname and certificate verification
+            if tlsmode > 1:
+                ctx.check_hostname = False
+                ctx.verify_mode = ssl.CERT_NONE
+
+            self.socket = ctx.wrap_socket(self.socket, server_hostname=host)
+
         self.socket.connect((host, port))
         self.send(3, password)
 


### PR DESCRIPTION
Added "tlsmode" to connect(). Acceptable values are 0 = off, 1 = strict, 2 = lax

Works great when wrapping Minecraft RCON with stunnel, and probably on other occasions as well

~~Didn't test with Py3, but I don't think there will be any issues there~~